### PR TITLE
Pass original collections to callbacks in helpers

### DIFF
--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -6,14 +6,30 @@ describe('helpers', () => {
     it('returns a function that maps the values of an object', async () => {
       const result = await source({a: {value: 1}, b: {value: 2}, c: {value: 3}})
         .pipe(
-          mapValues((num, key) => ({times2: num.value * 2, originalKey: key}))
+          mapValues((num, key, collection) => ({
+            times2: num.value * 2,
+            originalKey: key,
+            collection,
+          }))
         )
         .flow();
 
       expect(result).toEqual({
-        a: {times2: 2, originalKey: 'a'},
-        b: {times2: 4, originalKey: 'b'},
-        c: {times2: 6, originalKey: 'c'},
+        a: {
+          times2: 2,
+          originalKey: 'a',
+          collection: {a: {value: 1}, b: {value: 2}, c: {value: 3}},
+        },
+        b: {
+          times2: 4,
+          originalKey: 'b',
+          collection: {a: {value: 1}, b: {value: 2}, c: {value: 3}},
+        },
+        c: {
+          times2: 6,
+          originalKey: 'c',
+          collection: {a: {value: 1}, b: {value: 2}, c: {value: 3}},
+        },
       });
     });
   });
@@ -22,14 +38,18 @@ describe('helpers', () => {
     it('returns a function that maps the items of an array', async () => {
       const result = await source([1, 2, 3])
         .pipe(
-          mapItems((num, index) => ({times2: num * 2, originalIndex: index}))
+          mapItems((num, index, collection) => ({
+            times2: num * 2,
+            originalIndex: index,
+            collection,
+          }))
         )
         .flow();
 
       expect(result).toEqual([
-        {times2: 2, originalIndex: 0},
-        {times2: 4, originalIndex: 1},
-        {times2: 6, originalIndex: 2},
+        {times2: 2, originalIndex: 0, collection: [1, 2, 3]},
+        {times2: 4, originalIndex: 1, collection: [1, 2, 3]},
+        {times2: 6, originalIndex: 2, collection: [1, 2, 3]},
       ]);
     });
   });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,9 +8,9 @@
  * @returns A function that maps an array of items using the given callback.
  */
 export function mapItems<T, R>(
-  callback: (arg: T, index: number) => R
+  callback: (arg: T, index: number, collection: T[]) => R
 ): (arg: T[]) => R[] {
-  return (data) => data.map((item, index) => callback(item, index));
+  return (data) => data.map(callback);
 }
 
 /**
@@ -23,13 +23,13 @@ export function mapItems<T, R>(
  * @returns A function that maps the values of an object using the given callback.
  */
 export function mapValues<T extends Record<any, any>, R>(
-  callback: (value: T[keyof T], key: keyof T) => R
+  callback: (value: T[keyof T], key: keyof T, collection: T) => R
 ) {
   return (data: T) => {
     return Object.keys(data).reduce((acc, key) => {
       return {
         ...acc,
-        [key]: callback(data[key], key),
+        [key]: callback(data[key], key, data),
       };
     }, {} as {[key in keyof T]: R});
   };


### PR DESCRIPTION
This allows us to be able to use the original value without creating an intermediate callback.